### PR TITLE
Fixed footer image links for posts

### DIFF
--- a/NetDream/partials/postfooter.hbs
+++ b/NetDream/partials/postfooter.hbs
@@ -1,0 +1,26 @@
+<footer>
+    <!--Footer-->
+    {{{@config.custom.footerText}}}
+    <div>
+        <img src="../assets/img/netscape.gif" />
+        <a href="https://getfirefox.org" target="_blank">
+            <img src="../assets/img/firefox2.gif" />
+        </a>
+        <a href="https://www.waterfox.net/" target="_blank">
+            <img src="../assets/img/waterfox.gif" />
+        </a>
+    </div>
+</footer> <!--Index-->
+
+<script async src="{{js "scripts.js"}}"></script>
+
+{{! code injection by a Custom HTML tool }}
+{{{@footerCustomCode}}}
+{{! /code injection by a Custom HTML tool }}
+
+{{! helper for creating footer output with Publii-related tags. Currently used for GDPR cookies popup }}
+{{{ publiiFooter }}}
+{{! /helper for creating footer output with Publii-related tags. Currently used for GDPR cookies popup }}
+
+</body>
+</html>

--- a/NetDream/post.hbs
+++ b/NetDream/post.hbs
@@ -56,5 +56,5 @@
 {{/post}}
 
 <footer>
-    {{> footer}}
+    {{> postfooter}}
 </footer>


### PR DESCRIPTION
Since posts are created in their own folders, the images used for the footer links were not working.

Added a new postfooter.hbs used for posts that changes the image source from ./assets/img/ to ../assets/img/.